### PR TITLE
Libtools update and Archive Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 libpipeline-1.5.6/
 log/
+install/

--- a/buildenv
+++ b/buildenv
@@ -38,6 +38,10 @@ ZZ
 
 }
 
+zopen_post_install()
+{
+   cd "$1/lib" && ar -d libpipeline.a libgnu_la-reallocarray.o
+}
 zopen_get_version()
 {
   echo ${VER}

--- a/patches/configure.patch
+++ b/patches/configure.patch
@@ -1,0 +1,15 @@
+diff --git a/configure b/configure
+index f983402..b52b148 100755
+--- a/configure
++++ b/configure
+@@ -10565,6 +10565,10 @@ openbsd* | bitrig*)
+   fi
+   ;;
+ 
++openedition)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
++
+ osf3* | osf4* | osf5*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;


### PR DESCRIPTION
remove extraneous (and problematic) .o from archive so consumers can pull in their own
 - when 'man-db' builds, it ends up getting a mix of gnulib .o's from it's code as well as libpipeline which causes an abend
add openedition to configure re: FAQ on libtools
 - [Rationale](https://zosopentools.github.io/meta/#/Guides/CommonSolutions?id=libtool-complains-that-passing-o-object-files-as-libraries-is-not-allowed) 